### PR TITLE
refactor updateStory(...) to updateStorySize(...) Fixes #7

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,14 +132,13 @@ Output:
   _id: '5a1c556c9904c700a3d3628e' }
   ```
 
- **Updating a story**
+ **Updating a story's size**
 
  ```javascript
 var storyId = '5a1c556c9904c700a3d3628e';
+var size = 3; // or var size = '3' (size can also be a string var)
 
-var story = {size: '3'};
-
-client.updateStory(storyId, story, function(err, data, response) {
+client.updateStorySize(storyId, size, function(err, data, response) {
   if (err) {
     console.log(err.message);
   } else {

--- a/client.js
+++ b/client.js
@@ -55,11 +55,11 @@ var client = function () {
     });
   };
 
-  this.updateStory = function (storyId,fields, callback) {
+  this.updateStorySize = function (storyId, size, callback) {
     var url = this.baseUrl + '/stories';
     url = url + '/' + storyId;
     var args = {
-      data: fields,
+      data: {"size": size.toString()},
       headers: { "Content-Type": "application/json" }
     };
     this.restClient.put(url, args, function (data, response) {

--- a/spec/story/story.spec.js
+++ b/spec/story/story.spec.js
@@ -69,7 +69,7 @@ describe('testing creating a new voter story', function () {
     });
 });
 
-describe('testing updating a voter story', function () {
+describe('testing updating a voter story\'s size', function () {
     var storyId;
     var newStory = {
         name: 'Update API Client',
@@ -87,8 +87,7 @@ describe('testing updating a voter story', function () {
     });
 
     it('should update story with a size and return a code 200', function (done) {
-        var updates = { size: '1' };
-        client.updateStory(storyId, updates, function (err, data, response) {
+        client.updateStorySize(storyId, '1', function (err, data, response) {
             expect(response.statusCode).to.equal(200);
             expect(data.size).to.equal('1');
             done();
@@ -96,8 +95,7 @@ describe('testing updating a voter story', function () {
     });
 
     it('should change the existing size of a story and return a code 200', function (done) {
-        var updates = { size: '3' };
-        client.updateStory(storyId, updates, function (err, data, response) {
+        client.updateStorySize(storyId, 3, function (err, data, response) {
             expect(response.statusCode).to.equal(200);
             expect(data.size).to.equal('3');
             done();
@@ -192,7 +190,7 @@ describe('testing get all stories', function () {
     });
 
     it('should return a story object with valid keys', function () {
-        expect(call_data[0]).to.have.include.keys('_id', 'updatedAt', 'createdAt', 'name', 'url');
+        expect(call_data[1]).to.have.include.keys('_id', '__v', 'updatedAt', 'createdAt', 'name', 'url', 'source');
     });
 
 });


### PR DESCRIPTION
Fixes #7 

https://waffle.io/AgileVentures/asyncvoter-slack-command/cards/5a5cd1d2fd3a5e00baa22988

Refactor updateStory to updateStorySize and change method parameters to require size as `int` or `string`.  Tests and README also updated to reflect changes.